### PR TITLE
Add Unit Test CI to `packages/contracts` for Early Detection of Code Breakages

### DIFF
--- a/.github/workflows/contracts-ci.yaml
+++ b/.github/workflows/contracts-ci.yaml
@@ -1,12 +1,15 @@
 name: Contracts CI
 
 on:
+  push:
+    paths:
+      - 'packages/contracts/**/*.sol'
   pull_request:
     paths:
       - 'packages/contracts/**/*.sol'
 
 jobs:
-  format:
+  contracts:
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -21,3 +24,6 @@ jobs:
       - name: Check Solidity formatting
         id: format
         run: make format_check
+
+      - name: Execute Unit Test
+        run: make test

--- a/packages/contracts/Makefile
+++ b/packages/contracts/Makefile
@@ -8,6 +8,9 @@ format:
 format_check:
 	forge fmt --check --root $(ROOT_DIR)
 
+.PHONY: test
+test:
+	forge test --root $(ROOT_DIR)
 
 setup:
 	node ./script/circom-verifier-setup.js

--- a/packages/contracts/src/managers/ZKEIP1271Manager.sol
+++ b/packages/contracts/src/managers/ZKEIP1271Manager.sol
@@ -21,7 +21,7 @@ abstract contract ZKEIP1271Manager is ZKAuth, ZKOwnerManager {
      * @param signature Signature of the data
      * @return magicValue Magic value if the signature is valid or invalid id / invalid time range
      */
-    function isValidSignature(bytes32 hash, bytes calldata signature) external view returns (bytes4 magicValue) {
+    function isValidSignature(bytes32 hash, bytes calldata signature) external pure returns (bytes4 magicValue) {
         // todo
         (hash, signature);
         return _INVALID_ID;
@@ -36,7 +36,7 @@ abstract contract ZKEIP1271Manager is ZKAuth, ZKOwnerManager {
      */
     function _isValidSignature(bytes32 hash, bytes calldata signature)
         internal
-        view
+        pure
         returns (uint256 validationData, bool isValid)
     {
         // todo


### PR DESCRIPTION
## Description

In this pull request, we are adding a step to run forge test -vvv in the CI for packages/contracts, as introduced in the #33  pull request.

This addition helps prevent situations where changes are merged into branches like 'develop' without running tests during development, potentially causing code breakages that could impact stakeholders and many developers.

## Key Changes

- Addition of forge test to Makefile
  - We added forge test -vvv to the 'test' target in the Makefile.
- Adding Push Trigger and Test Step to CI Workflow
  - In addition to the trigger from the #33  pull request, we've configured the CI workflow to execute when there are changes to .sol code in packages/contracts due to a push event. We've also added the test step, ensuring that tests run every time the CI workflow is triggered.

These changes will contribute to a more stable development process and help establish clear guidelines for our development efforts.

## Other Changes

While running the compilation, I also made changes to the visibility modifiers of `packages/contracts/src/managers/ZKEIP1271Manager.sol` to address the warnings.