### PR TITLE
Fix Issues with Makefile in circom-circuit Directory 

### DIFF
--- a/packages/circom-circuit/Makefile
+++ b/packages/circom-circuit/Makefile
@@ -1,7 +1,7 @@
 init:
-	mkdir ./setup && mkdir ./build
+	mkdir -p ./setup && mkdir -p ./build
 	cp ./test/input.json ./setup/input.json
-	curl -L https://hermez.s3-eu-west-1.amazonaws.com/powersOfTau28_hez_final_19.ptau -o ./setup/powersOfTau28_hez_final_19.ptau
+	curl -L https://hermez.s3-eu-west-1.amazonaws.com/powersOfTau28_hez_final_20.ptau -o ./setup/powersOfTau28_hez_final_20.ptau
 
 test-circuit:
 	npm run test
@@ -15,23 +15,23 @@ user-sig-build-circuit:
 	node user-sig-build/verify-user-sig_js/generate_witness.js ./user-sig-build/verify-user-sig_js/verify-user-sig.wasm ./user-sig-setup/input.json ./user-sig-setup/witness.wtns
 
 gov-sig-setup-groth16:
-	snarkjs groth16 setup ./gov-sig-build/verify-gov-sig.r1cs ./powersOfTau28_hez_final_20.ptau ./gov-sig-setup/circuit_0000.zkey
+	snarkjs groth16 setup ./gov-sig-build/verify-gov-sig.r1cs ./setup/powersOfTau28_hez_final_20.ptau ./gov-sig-setup/circuit_0000.zkey
 	snarkjs zkey contribute ./gov-sig-setup/circuit_0000.zkey ./gov-sig-setup/circuit_0001.zkey --name="1st Contributor Name 1" -v -e="1st random entropy"
 	snarkjs zkey contribute ./gov-sig-setup/circuit_0001.zkey ./gov-sig-setup/circuit_0002.zkey --name="2st Contributor Name 2" -v -e="2st random entropy"
 	snarkjs zkey contribute ./gov-sig-setup/circuit_0002.zkey ./gov-sig-setup/circuit_0003.zkey --name="3st Contributor Name 3" -v -e="3st random entropy"
-	snarkjs zkey verify ./gov-sig-build/verify-gov-sig.r1cs ./powersOfTau28_hez_final_20.ptau ./gov-sig-setup/circuit_0003.zkey
+	snarkjs zkey verify ./gov-sig-build/verify-gov-sig.r1cs ./setup/powersOfTau28_hez_final_20.ptau ./gov-sig-setup/circuit_0003.zkey
 	snarkjs zkey beacon ./gov-sig-setup/circuit_0003.zkey ./gov-sig-setup/circuit_final.zkey 0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f 10 -n="Final Beacon phase2"
-	snarkjs zkey verify ./gov-sig-build/verify-gov-sig.r1cs ./powersOfTau28_hez_final_20.ptau ./gov-sig-setup/circuit_final.zkey
+	snarkjs zkey verify ./gov-sig-build/verify-gov-sig.r1cs ./setup/powersOfTau28_hez_final_20.ptau ./gov-sig-setup/circuit_final.zkey
 	snarkjs zkey export verificationkey ./gov-sig-setup/circuit_final.zkey ./gov-sig-setup/verification_key.json
 
 user-sig-setup-groth16:
-	snarkjs groth16 setup ./user-sig-build/verify-user-sig.r1cs ./powersOfTau28_hez_final_20.ptau ./user-sig-setup/circuit_0000.zkey
+	snarkjs groth16 setup ./user-sig-build/verify-user-sig.r1cs ./setup/powersOfTau28_hez_final_20.ptau ./user-sig-setup/circuit_0000.zkey
 	snarkjs zkey contribute ./user-sig-setup/circuit_0000.zkey ./user-sig-setup/circuit_0001.zkey --name="1st Contributor Name 1" -v -e="1st random entropy"
 	snarkjs zkey contribute ./user-sig-setup/circuit_0001.zkey ./user-sig-setup/circuit_0002.zkey --name="2st Contributor Name 2" -v -e="2st random entropy"
 	snarkjs zkey contribute ./user-sig-setup/circuit_0002.zkey ./user-sig-setup/circuit_0003.zkey --name="3st Contributor Name 3" -v -e="3st random entropy"
-	snarkjs zkey verify ./user-sig-build/verify-user-sig.r1cs ./powersOfTau28_hez_final_20.ptau ./user-sig-setup/circuit_0003.zkey
+	snarkjs zkey verify ./user-sig-build/verify-user-sig.r1cs ./setup/powersOfTau28_hez_final_20.ptau ./user-sig-setup/circuit_0003.zkey
 	snarkjs zkey beacon ./user-sig-setup/circuit_0003.zkey ./user-sig-setup/circuit_final.zkey 0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f 10 -n="Final Beacon phase2"
-	snarkjs zkey verify ./user-sig-build/verify-user-sig.r1cs ./powersOfTau28_hez_final_20.ptau ./user-sig-setup/circuit_final.zkey
+	snarkjs zkey verify ./user-sig-build/verify-user-sig.r1cs ./setup/powersOfTau28_hez_final_20.ptau ./user-sig-setup/circuit_final.zkey
 	snarkjs zkey export verificationkey ./user-sig-setup/circuit_final.zkey ./user-sig-setup/verification_key.json
 
 gov-sig-create-proof:


### PR DESCRIPTION
## Description

This update in the `myna-wallet-monorepo/packages/circom-circuit` package's Makefile addresses specific issues related to directory creation and file paths. The changes enhance the overall functionality and ensure the correct setup for circuit compilation and verification.

## Key Changes

1. **Directory Creation Command Improvement**: Updated the `init` target from `mkdir ./setup && mkdir ./build` to `mkdir -p ./setup && mkdir -p ./build`. This change prevents errors if directories already exist.

2. **Updating Powers of Tau File Download URL**: Changed the curl command from downloading `powersOfTau28_hez_final_19.ptau` to `powersOfTau28_hez_final_20.ptau`, ensuring the script uses the latest version of the file.

3. . **Correct File Paths for Powers of Tau Files**: Adjusted file paths in `gov-sig-build-circuit` and `user-sig-build-circuit` targets. 

## Related Issue
https://github.com/MynaWallet/monorepo/issues/50